### PR TITLE
Enhance Twigwind configuration with animations and size rules

### DIFF
--- a/build.cjs
+++ b/build.cjs
@@ -196,6 +196,13 @@ function build() {
     return;
   }
 
+  // Compile @keyframes from config animations before processing any HTML
+  try {
+    tw.compileAnimations();
+  } catch (err) {
+    log.warn(`Could not compile animations: ${err.message || err}`);
+  }
+
   for (const file of htmlFiles) {
     try {
       let html;

--- a/src/css.js
+++ b/src/css.js
@@ -79,7 +79,9 @@ const Twigwind = (() => {
 
     font_sizes = { sm: "0.875rem", md: "1rem", lg: "1.125rem", xl: "1.25rem", xxl: "1.5rem" };
     components = {};
+    animations = {};
     variables = {};
+    animations = {};
   } else if (typeof module !== 'undefined' && module.exports) {
       try {
         const path = require('path');
@@ -94,6 +96,9 @@ const Twigwind = (() => {
           breakpoints = js.breakpoints || {};
           components = js.components || {};
           variables = js.variables || {};
+          display = js.display || {};
+          font_sizes = js.font_sizes || {};
+          animations = js.animations || {};
         }
       } catch (error) {
         raise(`Could not load twigwind.config.js: ${error.message || error}. Falling back to empty configuration.`);

--- a/src/css.js
+++ b/src/css.js
@@ -1145,7 +1145,7 @@ const Twigwind = (() => {
   rules = [
       { test: (p) => p.startsWith("bg-") || p.startsWith("color-"), run: twColor },
       { test: (p) => /^([pm][lrtb]?)-(\d+)(px|rem|em|%)?$/.test(p), run: twSpacing },
-      { test: (p) => /^(max|min)?-?(w|h)-(\d+%|\d+(?:px|rem|em|%)?)$/ || p.startsWith("size-"), run: twSize },
+      { test: (p) => /^(max|min)?-?(w|h)-(\d+%|\d+(?:px|rem|em|%)?)$/.test(p) || p.startsWith("size-"), run: twSize },
       { test: (p) => p.startsWith("flex"), run: twflex },
       { test: (p) => p.startsWith("grid:"), run: twGrid },
       { test: (p) => p.startsWith("border-radius"), run: twBorderRadius },

--- a/src/css.js
+++ b/src/css.js
@@ -15,6 +15,7 @@ const Twigwind = (() => {
   let font_sizes = {};
   let variables = {};
   let animations = {};
+  let animationCSS = "";
   let rules = [];
 
   /**
@@ -1026,6 +1027,66 @@ const Twigwind = (() => {
     }
   };
 
+  /**
+   * Compile all animations from the `animations` config into @keyframes CSS.
+   *
+   * Expected config format:
+   *   animations: {
+   *     "fade-in": {
+   *       "0%":   { opacity: "0" },
+   *       "100%": { opacity: "1" }
+   *     },
+   *     "slide-up": {
+   *       "from": { transform: "translateY(100%)", opacity: "0" },
+   *       "to":   { transform: "translateY(0)", opacity: "1" }
+   *     }
+   *   }
+   *
+   * Produces:
+   *   @keyframes fade-in { 0% { opacity: 0; } 100% { opacity: 1; } }
+   *   @keyframes slide-up { from { transform: translateY(100%); opacity: 0; } to { ... } }
+   */
+  const compileAnimations = () => {
+    animationCSS = "";
+
+    if (!animations || typeof animations !== 'object') {
+      return animationCSS;
+    }
+
+    const names = Object.keys(animations);
+    if (names.length === 0) return animationCSS;
+
+    for (const name of names) {
+      const keyframes = animations[name];
+      if (!keyframes || typeof keyframes !== 'object') {
+        raise(`compileAnimations: animation "${name}" is not a valid keyframes object. Skipping.`);
+        continue;
+      }
+
+      let rule = `@keyframes ${name} {\n`;
+
+      for (const [stop, props] of Object.entries(keyframes)) {
+        if (!props || typeof props !== 'object') {
+          raise(`compileAnimations: keyframe stop "${stop}" in animation "${name}" is not an object. Skipping.`);
+          continue;
+        }
+
+        rule += `  ${stop} {\n`;
+        for (const [prop, val] of Object.entries(props)) {
+          // Convert camelCase to kebab-case (e.g. backgroundColor -> background-color)
+          const cssProp = prop.replace(/([A-Z])/g, '-$1').toLowerCase();
+          rule += `    ${cssProp}: ${val};\n`;
+        }
+        rule += `  }\n`;
+      }
+
+      rule += `}\n`;
+      animationCSS += rule;
+    }
+
+    return animationCSS;
+  };
+
   const twTextDecoration = (cls, cname) => {
     if (used.has(cls)) return;
     used.add(cls);
@@ -1210,6 +1271,11 @@ const Twigwind = (() => {
     try {
       let final = "";
 
+      // Prepend compiled @keyframes animations
+      if (animationCSS) {
+        final += animationCSS + "\n";
+      }
+
       for (const [selector, rules] of Object.entries(css)) {
         if (!Array.isArray(rules)) {
           raise(`twInject: rules for selector "${selector}" is not an array. Skipping.`);
@@ -1241,9 +1307,16 @@ const Twigwind = (() => {
     twColor, twSpacing, twSize, twflex, twGrid, twBorder, twBorderRadius,
     twTransform, twLinearGradient, twshadow, twPosition, twText, twTypography, twLayout,
     twTransition, twOpacity, twFilter, twApply, twInject, applyUtilityClass, twDisplay,
+    compileAnimations,
     getCSS: () => {
       try {
         let out = "";
+
+        // Prepend compiled @keyframes animations
+        if (animationCSS) {
+          out += animationCSS + "\n";
+        }
+
         for (const [selector, rules] of Object.entries(css)) {
           if (!Array.isArray(rules)) continue;
           out += `${selector} {\n${rules.join("\n")}\n}\n`;
@@ -1254,7 +1327,7 @@ const Twigwind = (() => {
         return "";
       }
     },
-    reset: () => { for (const key in css) delete css[key]; used.clear(); errors.length = 0; },
+    reset: () => { for (const key in css) delete css[key]; used.clear(); errors.length = 0; animationCSS = ""; },
     Object_Model: () => twigom,
     raise,
     getErrors: () => [...errors],

--- a/src/css.js
+++ b/src/css.js
@@ -1079,7 +1079,7 @@ const Twigwind = (() => {
   rules = [
       { test: (p) => p.startsWith("bg-") || p.startsWith("color-"), run: twColor },
       { test: (p) => /^([pm][lrtb]?)-(\d+)(px|rem|em|%)?$/.test(p), run: twSpacing },
-      { test: (p) => /^(w|h)-/.test(p) || p.startsWith("size-"), run: twSize },
+      { test: (p) => /^(max|min)?-?(w|h)-(\d+%|\d+(?:px|rem|em|%)?)$/ || p.startsWith("size-"), run: twSize },
       { test: (p) => p.startsWith("flex"), run: twflex },
       { test: (p) => p.startsWith("grid:"), run: twGrid },
       { test: (p) => p.startsWith("border-radius"), run: twBorderRadius },
@@ -1097,7 +1097,6 @@ const Twigwind = (() => {
       { test: (p) => p.startsWith("font-") || /^font-(size|weight|family|style|variant):/.test(p), run: twTypography },
       { test: (p) => p.startsWith("animate-"), run: twAnimation },
       { test: (p) =>
-          p.startsWith("max-w-") ||
           p === "mx-auto" ||
           p === "my-auto" ||
           /^gap-/.test(p),

--- a/src/css.js
+++ b/src/css.js
@@ -14,7 +14,7 @@ const Twigwind = (() => {
   let display = {};
   let font_sizes = {};
   let variables = {};
-
+  let animations = {};
   let rules = [];
 
   /**

--- a/twigwind.config.js
+++ b/twigwind.config.js
@@ -40,9 +40,56 @@ const display = {
 const sizes = { sm: "40px", md: "80px", lg: "160px", xl: "320px", xxl: "640px"};
 const breakpoints = { sm: 640, md: 768, lg: 1024, xl: 1280, "2xl": 1536 };
 const font_sizes = { sm: "0.875rem", md: "1rem", lg: "1.125rem", xl: "1.25rem", xxl: "1.5rem" }; 
-const variables = { "black": "#000000", "white": "#ffffff", "transparent": "transparent" }; // Add more variables as needed
+const variables = { "black": "#000000", "white": "#ffffff"}; // Add more variables as needed
 const components = {};
-const animations = {};
+
+const animations = {
+  "fade-in": {
+    "0%":   { opacity: "0" },
+    "100%": { opacity: "1" }
+  },
+  "fade-out": {
+    "0%":   { opacity: "1" },
+    "100%": { opacity: "0" }
+  },
+  "slide-up": {
+    "from": { transform: "translateY(100%)", opacity: "0" },
+    "to":   { transform: "translateY(0)", opacity: "1" }
+  },
+  "slide-down": {
+    "from": { transform: "translateY(-100%)", opacity: "0" },
+    "to":   { transform: "translateY(0)", opacity: "1" }
+  },
+  "slide-left": {
+    "from": { transform: "translateX(100%)", opacity: "0" },
+    "to":   { transform: "translateX(0)", opacity: "1" }
+  },
+  "slide-right": {
+    "from": { transform: "translateX(-100%)", opacity: "0" },
+    "to":   { transform: "translateX(0)", opacity: "1" }
+  },
+  "bounce": {
+    "0%, 100%": { transform: "translateY(0)" },
+    "50%":      { transform: "translateY(-25%)" }
+  },
+  "spin": {
+    "from": { transform: "rotate(0deg)" },
+    "to":   { transform: "rotate(360deg)" }
+  },
+  "pulse": {
+    "0%, 100%": { opacity: "1" },
+    "50%":      { opacity: "0.5" }
+  },
+  "scale-in": {
+    "from": { transform: "scale(0)", opacity: "0" },
+    "to":   { transform: "scale(1)", opacity: "1" }
+  },
+  "shake": {
+    "0%, 100%": { transform: "translateX(0)" },
+    "25%":      { transform: "translateX(-5px)" },
+    "75%":      { transform: "translateX(5px)" }
+  }
+};
 
 
 module.exports = {
@@ -54,4 +101,5 @@ module.exports = {
     components: components,
     display: display,
     variables: variables,
+    animations: animations,
 };

--- a/twigwind.config.js
+++ b/twigwind.config.js
@@ -42,6 +42,7 @@ const breakpoints = { sm: 640, md: 768, lg: 1024, xl: 1280, "2xl": 1536 };
 const font_sizes = { sm: "0.875rem", md: "1rem", lg: "1.125rem", xl: "1.25rem", xxl: "1.5rem" }; 
 const variables = { "black": "#000000", "white": "#ffffff", "transparent": "transparent" }; // Add more variables as needed
 const components = {};
+const animations = {};
 
 
 module.exports = {


### PR DESCRIPTION
- Added animationCSS variable (line 18) to store compiled @keyframes output
- Added  function that iterates over the animations config object and generates valid @keyframes CSS rules, with - -camelCase-to-kebab-case property conversion and error handling
- Updated [getCSS()](vscode-webview://1vmugtv0hkqsjki1i6eb48g22agji9mgnkb5inp11iqabufe5dsg/src/css.js:1310) to -prepend animationCSS before utility rules
- Updated [twInject()](vscode-webview://1vmugtv0hkqsjki1i6eb48g22agji9mgnkb5inp11iqabufe5dsg/src/css.js:1265) to prepend animationCSS when injecting into the DOM
- Updated [reset()](vscode-webview://1vmugtv0hkqsjki1i6eb48g22agji9mgnkb5inp11iqabufe5dsg/src/css.js:1331) to clear animationCSS
- Exported compileAnimations in the return object
- Added 11 built-in animations: fade-in, fade-out, slide-up, slide-down, slide-left, slide-right, bounce, spin, pulse, scale-in, shake
- Added animations to module.exports
## Usage
Define animations in the config as @keyframes stop objects:
```js
animations: {
  "my-anim": {
    "from": { opacity: "0", transform: "scale(0.5)" },
    "to":   { opacity: "1", transform: "scale(1)" }
  }
}
```
Then use them in HTML with the existing animate- utility class pattern:

```html
<div class="animate-my-anim-500ms-infinite">...</div>
```

The build will output both the @keyframes my-anim { ... } block and the .animate-my-anim-500ms-infinite { animation: my-anim 500ms infinite; } rule.